### PR TITLE
feature/m6 tier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ barrel_pct.py
 tmp_cfg
 code_data_ingest_pricefix_v*.py
 t/
+
+t/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ model_assets/
 *.yml
 barrel_pct.py
 tmp_cfg
+code_data_ingest_pricefix_v*.py
+t/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ data/
 model_assets/
 *.csv
 *.json
+.env
+.venv/
+*.yml
+barrel_pct.py
+tmp_cfg

--- a/code_utils_bankroll_v1.py
+++ b/code_utils_bankroll_v1.py
@@ -1,16 +1,16 @@
-"""
-code_utils_bankroll_v1 · PP-EDGE Milestone 5
-Kelly sizing with global + daily caps.
-"""
-def size_bet(edge_pp, bankroll_cfg, bankroll_state):
-    starting = bankroll_cfg["starting"]
-    kf = bankroll_cfg.get("kelly_fraction", 1.0)
-    raw = edge_pp * kf * starting
-    max_roll = bankroll_cfg.get("max_bet_fraction_of_roll",1.0) * starting
+def size_bet(edge_pp, bankroll_cfg, bankroll_state, tag=None):
+    start = bankroll_cfg['starting']
+    kf = bankroll_cfg.get('kelly_fraction', 1.0)
+    over = bankroll_cfg.get('sizing', {}).get('kelly_fraction_override', {})
+    if tag in over:
+        kf = over[tag]
+    raw = edge_pp * kf * start
+    max_roll = bankroll_cfg.get('max_bet_fraction_of_roll', 1.0) * start
     size = min(raw, max_roll)
-    daily_cap = bankroll_cfg.get("daily_max_staked_pct",1.0) * starting
-    used = bankroll_state.get("staked_today", 0.0)
-    if used >= daily_cap: return 0.0
+    daily_cap = bankroll_cfg.get('daily_max_staked_pct', 1.0) * start
+    used = bankroll_state.get('staked_today', 0.0)
+    if used >= daily_cap:
+        return 0.0
     size = min(size, daily_cap - used)
-    bankroll_state["staked_today"] = used + size
+    bankroll_state['staked_today'] = used + size
     return round(size, 2)

--- a/config_pp_edge_v6.8.yaml
+++ b/config_pp_edge_v6.8.yaml
@@ -52,3 +52,4 @@ data:
   weather_cache: data/cache/
 model_assets:
   hit_prob_v1: model_assets/model_v1.pkl
+min_edge_pp: 0.05

--- a/features_travel_miles.py
+++ b/features_travel_miles.py
@@ -1,4 +1,19 @@
-"""Travel-Miles feature stub"""
-import pandas as pd
-def travel_miles(df: pd.DataFrame) -> pd.Series:
-    return pd.Series(0.0, index=df.index, name="travel_miles")
+
+import pandas as pd, numpy as np
+
+def _haversine(lat1, lon1, lat2, lon2):
+    r=3958.8
+    lat1=np.radians(lat1); lat2=np.radians(lat2)
+    dlat=lat2-lat1
+    dlon=np.radians(lon2-lon1)
+    a=np.sin(dlat/2)**2+np.cos(lat1)*np.cos(lat2)*np.sin(dlon/2)**2
+    return r*2*np.arcsin(np.sqrt(a))
+
+def travel_miles(df:pd.DataFrame)->pd.Series:
+    d=df[['team','game_date','park_lat','park_lon']].copy()
+    d.sort_values(['team','game_date'],inplace=True)
+    d['prev_lat']=d.groupby('team')['park_lat'].shift()
+    d['prev_lon']=d.groupby('team')['park_lon'].shift()
+    miles=_haversine(d['prev_lat'],d['prev_lon'],d['park_lat'],d['park_lon']).fillna(0.0)
+    return miles.reindex(df.index).astype(float).rename('travel_miles')
+

--- a/features_travel_miles.py
+++ b/features_travel_miles.py
@@ -1,0 +1,4 @@
+"""Travel-Miles feature stub"""
+import pandas as pd
+def travel_miles(df: pd.DataFrame) -> pd.Series:
+    return pd.Series(0.0, index=df.index, name="travel_miles")

--- a/scripts/monte_carlo_bankroll.py
+++ b/scripts/monte_carlo_bankroll.py
@@ -1,0 +1,32 @@
+import pandas as pd, numpy as np, yaml, argparse, pathlib
+
+def _load_edges(path: pathlib.Path)->pd.DataFrame:
+    return pd.read_csv(path)
+
+def _load_cfg(path: pathlib.Path)->dict:
+    with open(path) as f: return yaml.safe_load(f)
+
+def simulate(edges: pd.DataFrame, unit: float, runs: int, seed: int)->np.ndarray:
+    rng=np.random.default_rng(seed)
+    stake=np.full(len(edges),unit)
+    payout=edges['payout'].values
+    win_p=edges['win_prob'].values
+    profit=(rng.binomial(1,win_p,(runs,len(edges)))*payout-stake).sum(axis=1)
+    return profit
+
+def main():
+    p=argparse.ArgumentParser()
+    p.add_argument('--edges',required=True)
+    p.add_argument('--config',default='config_pp_edge_v6.8.yaml')
+    p.add_argument('--runs',type=int,default=10000)
+    p.add_argument('--seed',type=int,default=42)
+    a=p.parse_args()
+    edges=_load_edges(pathlib.Path(a.edges))
+    cfg=_load_cfg(pathlib.Path(a.config))
+    unit=cfg['bankroll']['unit_stake']
+    bankroll=cfg['bankroll']['starting_bankroll']
+    results=bankroll+simulate(edges,unit,a.runs,a.seed)
+    q=np.percentile(results,[5,50,95]).round(2)
+    print({'p5':q[0],'p50':q[1],'p95':q[2]})
+if __name__=='__main__':
+    main()

--- a/scripts/scenario_simulator.py
+++ b/scripts/scenario_simulator.py
@@ -1,0 +1,23 @@
+import pandas as pd, argparse, pathlib, yaml
+
+def _load_edges(path: pathlib.Path)->pd.DataFrame:
+    return pd.read_csv(path)
+
+def _load_cfg(path: pathlib.Path)->dict:
+    with open(path) as f: return yaml.safe_load(f)
+
+def simulate(edges: pd.DataFrame, unit: float)->float:
+    profit=(edges['hit']*edges['payout']-unit).sum()
+    return profit
+
+def main():
+    p=argparse.ArgumentParser()
+    p.add_argument('--edges',required=True)
+    p.add_argument('--config',default='config_pp_edge_v6.8.yaml')
+    a=p.parse_args()
+    edges=_load_edges(pathlib.Path(a.edges))
+    cfg=_load_cfg(pathlib.Path(a.config))
+    unit=cfg['bankroll']['unit_stake']
+    print({'profit':round(simulate(edges,unit),2)})
+if __name__=='__main__':
+    main()

--- a/tests/test_bankroll_tiers.py
+++ b/tests/test_bankroll_tiers.py
@@ -1,0 +1,18 @@
+import pytest, yaml
+from code_utils_bankroll_v1 import size_bet
+
+cfg = {
+    'starting': 1000,
+    'kelly_fraction': 0.25,
+    'max_bet_fraction_of_roll': 1,
+    'daily_max_staked_pct': 1,
+    'sizing': {'kelly_fraction_override': {'Demon': 0.10, 'Goblin': 0.15}}
+}
+
+def test_default_kelly():
+    s = {}
+    assert size_bet(0.05, cfg, s) == pytest.approx(12.5)
+
+def test_demon_override():
+    s = {}
+    assert size_bet(0.05, cfg, s, tag='Demon') == pytest.approx(5.0)

--- a/tests/test_monte_carlo_bankroll.py
+++ b/tests/test_monte_carlo_bankroll.py
@@ -1,0 +1,7 @@
+import pandas as pd
+from scripts.monte_carlo_bankroll import simulate
+
+def test_simulate_basic():
+    df=pd.DataFrame({'win_prob':[0.55,0.45],'payout':[1.9,1.8]})
+    res=simulate(df,1,5000,0)
+    assert res.mean()>-1 and res.mean()<1

--- a/tests/test_scenario_simulator.py
+++ b/tests/test_scenario_simulator.py
@@ -3,4 +3,4 @@ from scripts.scenario_simulator import simulate
 
 def test_simulate_scenario():
     df=pd.DataFrame({'hit':[1,0,1],'payout':[1.9,2.0,1.8]})
-    assert simulate(df,1) == pytest.approx(1.7)
+    assert simulate(df,1) == pytest.approx(0.7)

--- a/tests/test_scenario_simulator.py
+++ b/tests/test_scenario_simulator.py
@@ -1,4 +1,4 @@
-import pandas as pd
+import pandas as pd, pytest
 from scripts.scenario_simulator import simulate
 
 def test_simulate_scenario():

--- a/tests/test_scenario_simulator.py
+++ b/tests/test_scenario_simulator.py
@@ -1,0 +1,6 @@
+import pandas as pd
+from scripts.scenario_simulator import simulate
+
+def test_simulate_scenario():
+    df=pd.DataFrame({'hit':[1,0,1],'payout':[1.9,2.0,1.8]})
+    assert simulate(df,1) == pytest.approx(1.7)

--- a/tests/test_travel_miles.py
+++ b/tests/test_travel_miles.py
@@ -1,0 +1,16 @@
+
+import pandas as pd
+from features_travel_miles import travel_miles
+
+def test_travel_miles_basic():
+    df=pd.DataFrame({
+        'team':['A','A','B'],
+        'game_date':pd.to_datetime(['2024-01-01','2024-01-02','2024-01-01']),
+        'park_lat':[37.7749,34.0522,40.7128],
+        'park_lon':[-122.4194,-118.2437,-74.0060]
+    })
+    m=travel_miles(df)
+    assert m.iloc[0]==0.0
+    assert m.iloc[1]>0.0
+    assert m.iloc[2]==0.0
+


### PR DESCRIPTION
- **cfg: set min_edge_pp 0.05 for MC baseline**
- **feat: add travel_miles stub**
- **chore: ignore local env and remove duplicates**
- **chore: ignore scratch scripts**
- **chore: ignore temp dir t**
- **feat: travel_miles haversine calc**
- **feat: monte carlo bankroll simulator**
- **feat: scenario simulator baseline**
- **test: add pytest import**
- **fix(test): correct scenario profit expectation**
- **feat: tier sizing with Demon/Goblin overrides**
